### PR TITLE
Update for current Rocky 8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,8 +9,8 @@ LABEL org.opencontainers.image.source="https://github.com/giovtorres/slurm-docke
 ARG SLURM_TAG=slurm-22-05-4-1
 ARG GOSU_VERSION=1.11
 
-RUN sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/Rocky-* && \
-    sed -i 's|#baseurl=|baseurl=|' /etc/yum.repos.d/Rocky-*
+RUN sed -i 's/^mirrorlist/#mirrorlist/g' /etc/yum.repos.d/Rocky-* && \
+    sed -i 's|^#baseurl=|baseurl=|' /etc/yum.repos.d/Rocky-*
 
 RUN set -ex \
     && yum makecache \
@@ -48,12 +48,6 @@ RUN pip3 install Cython nose
 
 RUN set -ex \
     && wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-amd64"
-#    && wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-amd64.asc"
-
-#RUN export GNUPGHOME="$(mktemp -d)" \
-#    && gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
-#    && gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu \
-#    && rm -rf "${GNUPGHOME}" /usr/local/bin/gosu.asc
 
 RUN chmod +x /usr/local/bin/gosu \
     && gosu nobody true


### PR DESCRIPTION
Munge the repos.d locations.

Skip the verification for the gosu binary.  The .asc file is no longer available.

That means we can skip the gpg key. It's no longer available anyway.