### PR TITLE
Support multi architecture building

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ LABEL org.opencontainers.image.source="https://github.com/giovtorres/slurm-docke
 ARG SLURM_TAG=slurm-22-05-4-1
 ARG GOSU_VERSION=1.11
 ARG TARGETARCH
+ARG TARGETOS
 
 RUN sed -i 's/^mirrorlist/#mirrorlist/g' /etc/yum.repos.d/Rocky-* && \
     sed -i 's|^#baseurl=|baseurl=|' /etc/yum.repos.d/Rocky-*
@@ -108,7 +109,7 @@ RUN set -x \
         /var/log/slurmctld.log \
     && chown -R slurm:slurm /var/*/slurm* /jobs \
     && /sbin/create-munge-key \
-    && curl -k -LO "https://dl.k8s.io/release/$(curl -k -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/${TARGETARCH}/kubectl" \
+    && curl -k -LO "https://dl.k8s.io/release/$(curl -k -L -s https://dl.k8s.io/release/stable.txt)/bin/${TARGETOS}/${TARGETARCH}/kubectl" \
     && install -o slurm -g slurm -m 0755 kubectl /usr/local/bin/kubectl
 
 COPY cgroup.conf /etc/slurm/cgroup.conf

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ LABEL org.opencontainers.image.source="https://github.com/giovtorres/slurm-docke
 
 ARG SLURM_TAG=slurm-22-05-4-1
 ARG GOSU_VERSION=1.11
+ARG TARGETARCH
 
 RUN sed -i 's/^mirrorlist/#mirrorlist/g' /etc/yum.repos.d/Rocky-* && \
     sed -i 's|^#baseurl=|baseurl=|' /etc/yum.repos.d/Rocky-*
@@ -47,7 +48,7 @@ RUN alternatives --set python /usr/bin/python3
 RUN pip3 install Cython nose
 
 RUN set -ex \
-    && wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-amd64"
+    && wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-${TARGETARCH}"
 
 RUN chmod +x /usr/local/bin/gosu \
     && gosu nobody true
@@ -107,7 +108,7 @@ RUN set -x \
         /var/log/slurmctld.log \
     && chown -R slurm:slurm /var/*/slurm* /jobs \
     && /sbin/create-munge-key \
-    && curl -k -LO "https://dl.k8s.io/release/$(curl -k -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl" \
+    && curl -k -LO "https://dl.k8s.io/release/$(curl -k -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/${TARGETARCH}/kubectl" \
     && install -o slurm -g slurm -m 0755 kubectl /usr/local/bin/kubectl
 
 COPY cgroup.conf /etc/slurm/cgroup.conf


### PR DESCRIPTION
I'm running through the example at https://github.com/DataWorkflowServices/dws-slurm-bb-plugin?tab=readme-ov-file#the-integration-test-environment-as-a-playground with the latest versions of everything and am making PRs based on changes I found I need for proper building on arm.

Using TARGETARCH in the dockerfile should retain functionality for amd64 and allow for building on other archs. It also opens up the possibility for multi arch images.
